### PR TITLE
Feat/log file

### DIFF
--- a/apps/build_dynamic_index.cpp
+++ b/apps/build_dynamic_index.cpp
@@ -7,6 +7,7 @@
 #include <string.h>
 #include <time.h>
 #include <timer.h>
+#include <log_utils.h>
 #include <boost/program_options.hpp>
 #include <future>
 
@@ -158,11 +159,16 @@ void build_dynamic_index(const std::string &data_path, diskann::IndexWriteParame
     std::cout << "load aligned bin succeeded" << std::endl;
     diskann::Timer timer;
     index->build(data, beginning_index_size, tags);
-    index->save(save_path.c_str(), true);
+
 
     const double elapsedSeconds = timer.elapsed() / 1000000.0;
     std::cout << "Initial non-incremental index build time for " << beginning_index_size << " points took "
             << elapsedSeconds << " seconds (" << beginning_index_size / elapsedSeconds << " points/second)\n ";
+    
+    get_log_file() << "initial_build_time: " << elapsedSeconds << std::endl;
+    
+
+    index->save(save_path.c_str(), true);
     diskann::aligned_free(data);
 }
 

--- a/include/log_utils.h
+++ b/include/log_utils.h
@@ -1,0 +1,8 @@
+#ifndef LOG_UTILS_H
+#define LOG_UTILS_H
+
+#include <fstream>
+
+std::ofstream& get_log_file();
+
+#endif  // LOG_UTILS_H

--- a/include/utils.h
+++ b/include/utils.h
@@ -736,6 +736,38 @@ inline size_t save_bin(const std::string &filename, T *data, size_t npts, size_t
     return bytes_written;
 }
 
+template <typename T>
+inline void save_vector1d(const std::string &filename, const std::vector<T> &vec) {
+    std::ofstream file(filename, std::ios::binary);
+    if (!file) {
+        std::cerr << "Error opening file: " << filename << std::endl;
+        return;
+    }
+
+    size_t size = vec.size();
+    file.write(reinterpret_cast<const char *>(&size), sizeof(size));
+    file.write(reinterpret_cast<const char *>(vec.data()), size * sizeof(T)); 
+}
+
+template <typename T>
+inline void save_vector2d(const std::string &filename, const std::vector<std::vector<T>> &vec) {
+    std::ofstream file(filename, std::ios::binary);
+    if (!file) {
+        std::cerr << "Error opening file: " << filename << std::endl;
+        return;
+    }
+
+    size_t rows = vec.size();
+    size_t cols = rows > 0 ? vec[0].size() : 0;
+
+    file.write(reinterpret_cast<const char *>(&rows), sizeof(rows));
+    file.write(reinterpret_cast<const char *>(&cols), sizeof(cols));
+
+    for (const auto &row : vec) {
+        file.write(reinterpret_cast<const char *>(row.data()), cols * sizeof(T));
+    }
+}
+
 inline void print_progress(double percentage)
 {
     int val = (int)(percentage * 100);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -12,7 +12,7 @@ else()
         distance.cpp index.cpp in_mem_graph_store.cpp in_mem_data_store.cpp
         linux_aligned_file_reader.cpp math_utils.cpp natural_number_map.cpp
         in_mem_data_store.cpp in_mem_graph_store.cpp
-        natural_number_set.cpp memory_mapper.cpp partition.cpp pq.cpp
+        natural_number_set.cpp memory_mapper.cpp partition.cpp pq.cpp log_utils.cpp
         pq_flash_index.cpp scratch.cpp logger.cpp utils.cpp filter_utils.cpp index_factory.cpp abstract_index.cpp pq_l2_distance.cpp pq_data_store.cpp)
     if (RESTAPI)
         list(APPEND CPP_SOURCES restapi/search_wrapper.cpp restapi/server.cpp)

--- a/src/log_utils.cpp
+++ b/src/log_utils.cpp
@@ -1,0 +1,18 @@
+#include "log_utils.h"
+#include <cstdlib>  // For getenv
+
+std::ofstream& get_log_file() {
+    static std::ofstream log_file;
+    static bool initialized = false;
+
+    if (!initialized) {
+        const char* log_path = std::getenv("DISKANN_LOG_FILE");
+        if (log_path) {
+            log_file.open(log_path, std::ios::app);
+        } else {
+            log_file.open("diskann_default.log", std::ios::app);  // Fallback
+        }
+        initialized = true;
+    }
+    return log_file;
+}


### PR DESCRIPTION
Simple log file logic.

The idea here is that we have a global environment variable for the current log file, and whenever we want to track metrics, we simply write to the return value of `get_log_file()`

TODO: Need to extend this to tail/mean latency, QPS, recall (e.g. all the statistics that search_memory_index prints out).